### PR TITLE
Minor README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Hello Plutarch helps you writing projects in Haskell that use
 [Plutarch](https://github.com/Plutonomicon/plutarch-plutus) libraries.
 
 To start a new project based on Hello Plutarch, you need either
-[nix](https://nixos.org) or [cabal](https://www.haskell.org/cabal/).
+[Nix](https://nixos.org) or [Cabal](https://www.haskell.org/cabal/).
 
-## Compile with nix
+## Compile with Nix
 
-_You must answer positively to the questions prompted by the following nix
+_You must answer positively to the questions prompted by the following Nix
 command to avoid compiling GHC several times._
 
 ```console
@@ -16,7 +16,7 @@ $ nix run
 (program 1.0.0 (\i0 -> \i0 -> \i0 -> ()))
 ```
 
-## Compile with cabal
+## Compile with Cabal
 
 Additional requirements:
 - ghc (>= 9.2)


### PR DESCRIPTION
1. Use `console` instead of `sh` for code snippets. Syntax colouring will then be aware of the fact that `$` is a prompt followed by Shell code, while other lines are just raw outputs. In particular, it will remove the weird colouring of `>` in the PLC output.
2. Capitalise Nix and Cabal; cf https://nixos.org/ and https://cabal.readthedocs.io/en/stable/ that do that.