### PR TITLE
Flake templates system

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Additional requirements:
 $ cabal run
 (program 1.0.0 (\i0 -> \i0 -> \i0 -> ()))
 ```
+
+## Use flake templates
+
+The repository also provides a Nix flake template.
+A fresh repository can be setup with
+```console
+$ nix flake init -t github:tweag/hello-plutarch
+```

--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,18 @@
     };
   };
 
-  outputs = { self, haskellNix, nixpkgs, flake-utils, CHaP }:
-  flake-utils.lib.eachSystem [ "x86_64-linux" ](system:
-    let
-      overlays = [ haskellNix.overlay
-      (final: prev: {
-        hello-plutarch =
-          final.haskell-nix.project' {
+  outputs = {
+    self,
+    haskellNix,
+    nixpkgs,
+    flake-utils,
+    CHaP,
+  }:
+    flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
+      overlays = [
+        haskellNix.overlay
+        (final: prev: {
+          hello-plutarch = final.haskell-nix.project' {
             src = ./.;
             compiler-nix-name = "ghc924";
             inputMap = {
@@ -31,18 +36,43 @@
           };
         })
       ];
-    pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
-    flake = pkgs.hello-plutarch.flake {};
-    in flake //
-    {
-      packages.default = flake.packages."hello-plutarch:exe:hello-plutarch";
-    });
+      pkgs = import nixpkgs {
+        inherit system overlays;
+        inherit (haskellNix) config;
+      };
+      flake = pkgs.hello-plutarch.flake {};
+    in
+      flake
+      // {
+        packages.default = flake.packages."hello-plutarch:exe:hello-plutarch";
 
-    nixConfig = {
-      ## Setup IOG caches, see
-      ## https://input-output-hk.github.io/haskell.nix/tutorials/getting-started.html#setting-up-the-binary-cache
-      extra-trusted-substituters = ["https://cache.iog.io"];
-      extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
-      allow-import-from-derivation = "true";
+        formatter = pkgs.alejandra;
+      })
+    // {
+      templates = {
+
+        haskellNix = {
+          description = "Plutarch project with `haskell.nix`";
+          path = ./.;
+          welcomeText = ''
+            # Plutarch project with a `haskell.nix` setup
+
+            Let Nix handle Haskell dependencies through `haskell.nix`.
+
+            ## More info
+            - [Plutarch](https://github.com/plutonomicon/plutarch-plutus)
+            - [`haskell.nix`](https://input-output-hk.github.io/haskell.nix)
+          '';
+        };
+        default = self.templates.haskellNix;
+      };
     };
+
+  nixConfig = {
+    ## Setup IOG caches, see
+    ## https://input-output-hk.github.io/haskell.nix/tutorials/getting-started.html#setting-up-the-binary-cache
+    extra-trusted-substituters = ["https://cache.iog.io"];
+    extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+    allow-import-from-derivation = "true";
+  };
 }


### PR DESCRIPTION
This PR tries to provide flake templates through the `templates` attribute, which allows to initialise fresh repositories using, _e.g._
```console
nix flake init -t github:tweag/hello-plutarch
```

There are several things to think of, and several compromises:
- Templates can be added in a `templates` sub directory. In that case, the current repository cannot be used as a "git repository template" (where a "git repository template" is a repository one clones and uses right away) because
  1. The flake is burdened with the `templates` sections
  2. The repository contains the `templates` directory
- The template can be declared to be the current repository. But then the initialisation also clones the `.github` folder with all the CI stuff (and the flake that is copied as template also contains the `templates` attribute set).
- The template can be computed by creating a derivation. This appears quite heavy.
- The template can be set up in a different branch.