### PR TITLE
Add a workflow to sync `main` and `template`

### DIFF
--- a/.github/workflows/template.yaml
+++ b/.github/workflows/template.yaml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-      - workflow-sync-main-template
-      ## ^^^ FIXME: remove when done testing
 
 jobs:
 
@@ -53,8 +51,7 @@ jobs:
           ## We act as the GitHub Actions bot on the `template` branch.
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git checkout niols/test-template
-          ## ^^^ FIXME: change when done testing
+          git checkout template
           ## Erase the `template` directory with what has been prepared before.
           rm -R ./template
           cp -R "$tmp" ./template
@@ -63,6 +60,5 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git add ./template
             git commit --message="$(cat "$COMMIT_MESSAGE_FILE")"
-            git push origin niols/test-template
-            ## ^^^ FIXME: change when done testing
+            git push origin template
           fi

--- a/cabal.project
+++ b/cabal.project
@@ -60,5 +60,3 @@ benchmarks: true
 
 -- The only sensible test display option.
 test-show-details: streaming
-
--- BONJOUR


### PR DESCRIPTION
This PR adds a workflow that, when triggered by commits on `main`, copies all of `main` into the sub-directory `template` of the branch `template`, therefore keeping them in sync.

*This is currently WIP and needs to be cleaned up before actually committing to `main`.*