### PR TITLE
Fix haskell.nix version to copy GHC 9.2.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1666576849,
-        "narHash": "sha256-FDFmN3TzQsUjNxGlKKTFpLOUOnvsQMNI4o3MahJw9zA=",
+        "lastModified": 1670900592,
+        "narHash": "sha256-SZlQp3W0WdxB00gO5A0krgDw7CLESm5jWZ6S+GPxCxA=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "97aab5bc3f59108d97a6bb0c4d07ae1b79b005ca",
+        "rev": "052db7f6a2d5d24cfce829868d1a54e339dea229",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -214,6 +214,7 @@
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "0.0.68",
         "repo": "haskell.nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
-    haskellNix.url = "github:input-output-hk/haskell.nix";
+    ## This version of haskell.nix allows to *copy* GHC 9.2.4
+    haskellNix.url = "github:input-output-hk/haskell.nix?ref=0.0.68";
     nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     ## See https://input-output-hk.github.io/cardano-haskell-packages/
@@ -11,7 +12,7 @@
   };
 
   outputs = { self, haskellNix, nixpkgs, flake-utils, CHaP }:
-  flake-utils.lib.eachSystem [ "x86_64-linux" ](system:
+  flake-utils.lib.eachDefaultSystem (system:
     let
       overlays = [ haskellNix.overlay
       (final: prev: {


### PR DESCRIPTION
In some cases, updating the flake causes `nix develop` to download GHC 9.2.4, which we want to avoid. We thus fix explicitly the version of `haskell.nix`.